### PR TITLE
✨ Support more log levels from Log4Net, XML files and rolling files

### DIFF
--- a/Analogy.LogViewer.Log4jXml/Core/Log/LogLevel.cs
+++ b/Analogy.LogViewer.Log4jXml/Core/Log/LogLevel.cs
@@ -6,11 +6,17 @@ namespace Logazmic.Core.Log
     public enum LogLevel
     {
         None = -1,
+        Verbose,
         Trace,
         Debug,
         Info,
+        Notice,
         Warn,
         Error,
-        Fatal
+        Severe,
+        Critical,
+        Alert,
+        Fatal,
+        Emergency
     }
 }

--- a/Analogy.LogViewer.Log4jXml/Core/Readers/LogReaderFactory.cs
+++ b/Analogy.LogViewer.Log4jXml/Core/Readers/LogReaderFactory.cs
@@ -30,6 +30,7 @@ namespace Logazmic.Core.Readers
                 case ".4JXML":
                 case ".LOG4JXML":
                 case ".LOG4J":
+                case ".XML":
                     return LogFormats.Log4J;
                 default:
                     return LogFormats.Flat;


### PR DESCRIPTION
Needed modifications for supporting Log4Net using Log4J XML format.

Adding support of:
- .XML files
- rolling files with suffix (*.xml.1, *.xml.2 ... *.xml.n)
- Adding some missing LogLevel